### PR TITLE
adds spanish TV channels and updates matches' channels

### DIFF
--- a/data.json
+++ b/data.json
@@ -125,6 +125,22 @@
       "country": "UK",
       "iso2": "en",
       "lang": "en"
+    },
+    {
+      "id": 6,
+      "name": "Cuatro",
+      "icon": "https://upload.wikimedia.org/wikipedia/commons/f/f8/Logotipo_de_Cuatro.svg",
+      "country": "Spain",
+      "iso2": "es",
+      "lang": "es"
+    },
+    {
+      "id": 7,
+      "name": "Telecinco",
+      "icon": "https://upload.wikimedia.org/wikipedia/commons/7/75/Telecinco_2012.png",
+      "country": "Spain",
+      "iso2": "es",
+      "lang": "es"
     }
   ],
   "teams": [
@@ -303,7 +319,7 @@
           "away_result": null,
           "date": "2018-06-14T18:00:00+03:00",
           "stadium": 1,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -315,7 +331,7 @@
           "away_result": null,
           "date": "2018-06-15T17:00:00+05:00",
           "stadium": 12,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -327,7 +343,7 @@
           "away_result": null,
           "date": "2018-06-19T21:00:00+03:00",
           "stadium": 3,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -339,7 +355,7 @@
           "away_result": null,
           "date": "2018-06-20T18:00:00+03:00",
           "stadium": 10,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -351,7 +367,7 @@
           "away_result": null,
           "date": "2018-06-25T18:00:00+04:00",
           "stadium": 7,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -363,7 +379,7 @@
           "away_result": null,
           "date": "2018-06-25T17:00:00+03:00",
           "stadium": 8,
-          "channels": [5],
+          "channels": [5,6],
           "finished": false
         }
       ]
@@ -381,7 +397,7 @@
           "away_result": null,
           "date": "2018-06-15T21:00:00+03:00",
           "stadium": 11,
-          "channels": [3],
+          "channels": [3,7],
           "finished": false
         },
         {
@@ -393,7 +409,7 @@
           "away_result": null,
           "date": "2018-06-15T18:00:00+03:00",
           "stadium": 3,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -405,7 +421,7 @@
           "away_result": null,
           "date": "2018-06-20T15:00:00+03:00",
           "stadium": 1,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -417,7 +433,7 @@
           "away_result": null,
           "date": "2018-06-20T21:00:00+03:00",
           "stadium": 5,
-          "channels": [4],
+          "channels": [4,7],
           "finished": false
         },
         {
@@ -429,7 +445,7 @@
           "away_result": null,
           "date": "2018-06-25T21:00:00+03:00",
           "stadium": 9,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -441,7 +457,7 @@
           "away_result": null,
           "date": "2018-06-25T20:00:00+02:00",
           "stadium": 4,
-          "channels": [3],
+          "channels": [3,7],
           "finished": false
         }
       ]
@@ -459,7 +475,7 @@
           "away_result": null,
           "date": "2018-06-16T13:00:00+03:00",
           "stadium": 5,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -471,7 +487,7 @@
           "away_result": null,
           "date": "2018-06-16T19:00:00+03:00",
           "stadium": 9,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -483,7 +499,7 @@
           "away_result": null,
           "date": "2018-06-21T20:00:00+05:00",
           "stadium": 12,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -495,7 +511,7 @@
           "away_result": null,
           "date": "2018-06-21T16:00:00+04:00",
           "stadium": 7,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -507,7 +523,7 @@
           "away_result": null,
           "date": "2018-06-26T17:00:00+03:00",
           "stadium": 1,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -519,7 +535,7 @@
           "away_result": null,
           "date": "2018-06-26T17:00:00+02:00",
           "stadium": 11,
-          "channels": [5],
+          "channels": [5,6],
           "finished": false
         }
       ]
@@ -537,7 +553,7 @@
           "away_result": null,
           "date": "2018-06-16T16:00:00+03:00",
           "stadium": 2,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -549,7 +565,7 @@
           "away_result": null,
           "date": "2018-06-16T21:00:00+02:00",
           "stadium": 4,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -561,7 +577,7 @@
           "away_result": null,
           "date": "2018-06-21T21:00:00+03:00",
           "stadium": 6,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -573,7 +589,7 @@
           "away_result": null,
           "date": "2018-06-22T18:00:00+03:00",
           "stadium": 8,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -585,7 +601,7 @@
           "away_result": null,
           "date": "2018-06-26T21:00:00+03:00",
           "stadium": 3,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -597,7 +613,7 @@
           "away_result": null,
           "date": "2018-06-26T21:00:00+03:00",
           "stadium": 10,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         }
       ]
@@ -615,7 +631,7 @@
           "away_result": null,
           "date": "2018-06-17T21:00:00+03:00",
           "stadium": 10,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -627,7 +643,7 @@
           "away_result": null,
           "date": "2018-06-17T16:00:00+04:00",
           "stadium": 7,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -639,7 +655,7 @@
           "away_result": null,
           "date": "2018-06-22T15:00:00+03:00",
           "stadium": 3,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -651,7 +667,7 @@
           "away_result": null,
           "date": "2018-06-22T20:00:00+02:00",
           "stadium": 4,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -663,7 +679,7 @@
           "away_result": null,
           "date": "2018-06-27T21:00:00+03:00",
           "stadium": 2,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -675,7 +691,7 @@
           "away_result": null,
           "date": "2018-06-27T21:00:00+03:00",
           "stadium": 6,
-          "channels": [5],
+          "channels": [5,6],
           "finished": false
         }
       ]
@@ -693,7 +709,7 @@
           "away_result": null,
           "date": "2018-06-17T18:00:00+03:00",
           "stadium": 1,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -705,7 +721,7 @@
           "away_result": null,
           "date": "2018-06-18T15:00:00+03:00",
           "stadium": 6,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -717,7 +733,7 @@
           "away_result": null,
           "date": "2018-06-23T21:00:00+03:00",
           "stadium": 11,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -729,7 +745,7 @@
           "away_result": null,
           "date": "2018-06-23T18:00:00+03:00",
           "stadium": 10,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -741,7 +757,7 @@
           "away_result": null,
           "date": "2018-06-27T17:00:00+03:00",
           "stadium": 5,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -753,7 +769,7 @@
           "away_result": null,
           "date": "2018-06-27T19:00:00+05:00",
           "stadium": 12,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         }
       ]
@@ -771,7 +787,7 @@
           "away_result": null,
           "date": "2018-06-18T18:00:00+03:00",
           "stadium": 11,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -783,7 +799,7 @@
           "away_result": null,
           "date": "2018-06-18T21:00:00+03:00",
           "stadium": 8,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -795,7 +811,7 @@
           "away_result": null,
           "date": "2018-06-23T15:00:00+03:00",
           "stadium": 2,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -807,7 +823,7 @@
           "away_result": null,
           "date": "2018-06-24T15:00:00+03:00",
           "stadium": 6,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -819,7 +835,7 @@
           "away_result": null,
           "date": "2018-06-28T20:00:00+02:00",
           "stadium": 4,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -831,7 +847,7 @@
           "away_result": null,
           "date": "2018-06-28T21:00:00+03:00",
           "stadium": 9,
-          "channels": [5],
+          "channels": [5,6],
           "finished": false
         }
       ]
@@ -849,7 +865,7 @@
           "away_result": null,
           "date": "2018-06-19T18:00:00+03:00",
           "stadium": 2,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -861,7 +877,7 @@
           "away_result": null,
           "date": "2018-06-19T15:00:00+03:00",
           "stadium": 9,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -873,7 +889,7 @@
           "away_result": null,
           "date": "2018-06-24T20:00:00+05:00",
           "stadium": 5,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -885,7 +901,7 @@
           "away_result": null,
           "date": "2018-06-24T21:00:00+03:00",
           "stadium": 12,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -897,7 +913,7 @@
           "away_result": null,
           "date": "2018-06-28T17:00:00+03:00",
           "stadium": 8,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -909,7 +925,7 @@
           "away_result": null,
           "date": "2018-06-28T18:00:00+04:00",
           "stadium": 7,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         }
       ]
@@ -946,7 +962,7 @@
           "winner": null,
           "date": "2018-06-30T21:00:00+03:00",
           "stadium": 5,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -976,7 +992,7 @@
           "winner": null,
           "date": "2018-07-01T21:00:00+03:00",
           "stadium": 6,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -991,7 +1007,7 @@
           "winner": null,
           "date": "2018-07-02T18:00:00+04:00",
           "stadium": 7,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -1006,7 +1022,7 @@
           "winner": null,
           "date": "2018-07-02T21:00:00+03:00",
           "stadium": 10,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         },
         {
@@ -1021,7 +1037,7 @@
           "winner": null,
           "date": "2018-07-03T17:00:00+03:00",
           "stadium": 3,
-          "channels": [4],
+          "channels": [4,6],
           "finished": false
         },
         {
@@ -1036,7 +1052,7 @@
           "winner": null,
           "date": "2018-07-03T21:00:00+03:00",
           "stadium": 2,
-          "channels": [3],
+          "channels": [3,6],
           "finished": false
         }
       ]


### PR DESCRIPTION
This PR adds spanish TV channels (Cuatro and Telecinco) to _tvchannels_ and updates matches' channels where possible. 
Telecinco will broadcast every match with Spain playing and Cuatro the rest of the tournament.